### PR TITLE
Fix ECS.hostname_from_task and Use a static app name.

### DIFF
--- a/lib/libcluster_ecs/ecs.ex
+++ b/lib/libcluster_ecs/ecs.ex
@@ -72,9 +72,11 @@ defmodule ClusterECS.ECS do
     %{network_interfaces: [%{private_ipv4_address: ip} | _]} =
       Enum.find(containers, &(&1.task_arn == task_arn))
 
+    dashed_ip = String.replace(ip, ".", "-")
+
     case region do
-      "us-east-1" -> "ip-#{ip}.ec2.internal"
-      region -> "ip-#{ip}.#{region}.compute.internal"
+      "us-east-1" -> "ip-#{dashed_ip}.ec2.internal"
+      region -> "ip-#{dashed_ip}.#{region}.compute.internal"
     end
   end
 

--- a/lib/libcluster_ecs/strategy/metadata.ex
+++ b/lib/libcluster_ecs/strategy/metadata.ex
@@ -128,7 +128,7 @@ defmodule ClusterECS.Strategy.Metadata do
     with {:ok, task_arns} <- ECS.list_task_arns(region, cluster_arn, service_name, opts),
          other_task_arns <- Enum.reject(task_arns, &(&1 == current_task_arn)),
          {:ok, tasks} <- ECS.describe_task_arns(region, cluster_arn, other_task_arns, opts) do
-      nodes = for task <- tasks, do: :"#{service_name}@#{ECS.hostname_from_task(region, task)}"
+      nodes = for task <- tasks, do: :"app@#{ECS.hostname_from_task(region, task)}"
 
       MapSet.new(nodes)
     else

--- a/test/cluster_ecs/ecs_test.exs
+++ b/test/cluster_ecs/ecs_test.exs
@@ -86,4 +86,34 @@ defmodule ClusterECS.ECSTest do
                })
     end
   end
+
+  describe "hostname_from_task/2" do
+    test "us-east-1 region" do
+      region = "us-east-1"
+      task_arn = Factory.build(:task_arn)
+      ip = Factory.build(:ipv4)
+      dashed_ip = String.replace(ip, ".", "-")
+
+      task = %{
+        task_arn: task_arn,
+        containers: [%{task_arn: task_arn, network_interfaces: [%{private_ipv4_address: ip}]}]
+      }
+
+      assert ECS.hostname_from_task(region, task) == "ip-#{dashed_ip}.ec2.internal"
+    end
+
+    test "another region" do
+      region = "us-east-2"
+      task_arn = Factory.build(:task_arn)
+      ip = Factory.build(:ipv4)
+      dashed_ip = String.replace(ip, ".", "-")
+
+      task = %{
+        task_arn: task_arn,
+        containers: [%{task_arn: task_arn, network_interfaces: [%{private_ipv4_address: ip}]}]
+      }
+
+      assert ECS.hostname_from_task(region, task) == "ip-#{dashed_ip}.#{region}.compute.internal"
+    end
+  end
 end


### PR DESCRIPTION
Why:

* The IP in the ECS hostnames should have dashes not periods.
* Using service name for the first part of a node name is too dynamic.

This change addresses the need by:

* Replace periods with dashes when generating a hostname.
* Change it from the service_name variable to "app".